### PR TITLE
fix: Avoid eager credentials creation and use credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 ### Fixed
+- Fix an issues with credentials in the Gradle Plugin (#9)
 
 ### Security
 


### PR DESCRIPTION
## What does this PR do?

Fix eager credentials creation in plugin initialization. Because we were using `repository.credentials` directly, a credentials instance was created each time, even for repositories without credentials. This PR fixes it by using the credentials provider (unfortunately internal, but we'll change if Gradle removes it).

## Issue number, if applicable

Fixes #9 

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.