### PR TITLE
refactor: use HTTP retry from ktor instead of using a cooked one

### DIFF
--- a/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
@@ -53,6 +53,7 @@ import com.deezer.caupain.serialization.DefaultJson
 import com.deezer.caupain.serialization.DefaultToml
 import com.deezer.caupain.serialization.DefaultXml
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -212,10 +213,14 @@ public fun DependencyUpdateChecker(
                 publicStorage(FileStorage(fileSystem, cacheDir))
             }
         }
+        install(HttpRequestRetry) {
+            retryOnException(maxRetries = 3, retryOnTimeout = true)
+            exponentialDelay(baseDelayMs = 500)
+        }
         install(HttpTimeout) {
             requestTimeoutMillis = 30_000
-            connectTimeoutMillis = 30_000
-            socketTimeoutMillis = 30_000
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 10_000
         }
     },
     ioDispatcher = ioDispatcher,

--- a/core/src/commonMain/kotlin/com/deezer/caupain/model/Repository.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/model/Repository.kt
@@ -32,7 +32,6 @@ import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpHeaders
 import io.ktor.http.URLBuilder
-import kotlinx.io.IOException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -83,18 +82,14 @@ public class Repository(
 internal suspend fun HttpClient.executeRepositoryRequest(
     repository: Repository,
     urlBuilder: URLBuilder.() -> Unit = {}
-): HttpResponse? = try {
-    get(repository.url) {
-        url(urlBuilder)
-        if (repository.user != null && repository.password != null) {
-            header(
-                HttpHeaders.Authorization,
-                "Basic ${Base64.encode("${repository.user}:${repository.password}".encodeToByteArray())}"
-            )
-        }
+): HttpResponse = get(repository.url) {
+    url(urlBuilder)
+    if (repository.user != null && repository.password != null) {
+        header(
+            HttpHeaders.Authorization,
+            "Basic ${Base64.encode("${repository.user}:${repository.password}".encodeToByteArray())}"
+        )
     }
-} catch (ignored: IOException) {
-    null
 }
 
 /**

--- a/core/src/commonMain/kotlin/com/deezer/caupain/resolver/UpdateInfoResolver.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/resolver/UpdateInfoResolver.kt
@@ -88,7 +88,7 @@ internal class UpdateInfoResolver(
             httpClient.executeRepositoryRequest(repository) {
                 appendPathSegments(group.split('.'))
                 appendPathSegments(name, updatedVersion.toString(), "$name-$resolvedUpdatedVersion.pom")
-            }?.takeIf { it.status.isSuccess() }?.body<MavenInfo>()
+            }.takeIf { it.status.isSuccess() }?.body<MavenInfo>()
         }
         // If this is a plugin, we need to find the real maven info by following the dependency
         return if (dependency is Dependency.Plugin && mavenInfo != null) {
@@ -124,7 +124,7 @@ internal class UpdateInfoResolver(
                 appendPathSegments(group.split('.'))
                 appendPathSegments(name, updatedVersion.toString(), "maven-metadata.xml")
             }
-        }?.takeIf { it.status.isSuccess() }?.body<Metadata>()
+        }.takeIf { it.status.isSuccess() }?.body<Metadata>()
         return snapshotMetadata
             ?.versioning
             ?.snapshotVersions


### PR DESCRIPTION
## What does this PR do?
Use [HttpRequestRetry](https://ktor.io/docs/client-request-retry.html) from ktor instead of handling retries ourselves

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.