### PR TITLE
feat: Grab repositories for Gradle plugin in subprojects also

### DIFF
--- a/cli/src/commonMain/kotlin/com/deezer/caupain/cli/model/Repository.kt
+++ b/cli/src/commonMain/kotlin/com/deezer/caupain/cli/model/Repository.kt
@@ -25,6 +25,7 @@
 package com.deezer.caupain.cli.model
 
 import com.deezer.caupain.model.buildComponentFilter
+import com.deezer.caupain.model.withComponentFilter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import com.deezer.caupain.model.Repository as ModelRepository

--- a/cli/src/commonTest/kotlin/com/deezer/caupain/cli/ConfigurationParsingTest.kt
+++ b/cli/src/commonTest/kotlin/com/deezer/caupain/cli/ConfigurationParsingTest.kt
@@ -31,6 +31,7 @@ import com.deezer.caupain.model.LibraryExclusion
 import com.deezer.caupain.model.PluginExclusion
 import com.deezer.caupain.model.Repository
 import com.deezer.caupain.model.buildComponentFilter
+import com.deezer.caupain.model.withComponentFilter
 import kotlinx.serialization.decodeFromString
 import okio.Path.Companion.toPath
 import org.intellij.lang.annotations.Language

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -123,9 +123,32 @@ public final class com/deezer/caupain/model/Configuration$Companion {
 	public static final field DEFAULT_GRADLE_VERSION_URL Ljava/lang/String;
 }
 
-public final class com/deezer/caupain/model/ConfigurationKt {
+public final class com/deezer/caupain/model/Configurations {
+	public static final fun Configuration ()Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;Z)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;)Lcom/deezer/caupain/model/Configuration;
 	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;Z)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;Z)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;)Lcom/deezer/caupain/model/Configuration;
 	public static final fun Configuration (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;Z)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Ljava/util/List;Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
+	public static final fun Configuration (Lokio/Path;)Lcom/deezer/caupain/model/Configuration;
 	public static synthetic fun Configuration$default (Ljava/util/List;Ljava/util/List;Ljava/lang/Iterable;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;ZILjava/lang/Object;)Lcom/deezer/caupain/model/Configuration;
 	public static synthetic fun Configuration$default (Ljava/util/List;Ljava/util/List;Lokio/Path;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lokio/Path;Lokio/Path;ZLjava/lang/String;ZILjava/lang/Object;)Lcom/deezer/caupain/model/Configuration;
 }
@@ -377,29 +400,22 @@ public abstract interface class com/deezer/caupain/model/Policy {
 	public abstract fun select (Lcom/deezer/caupain/model/Dependency;Lcom/deezer/caupain/model/versionCatalog/Version$Resolved;Lcom/deezer/caupain/model/GradleDependencyVersion$Static;)Z
 }
 
-public final class com/deezer/caupain/model/Repository : java/io/Serializable {
-	public static final field Companion Lcom/deezer/caupain/model/Repository$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun contains (Lcom/deezer/caupain/model/Dependency;)Z
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getComponentFilter ()Lcom/deezer/caupain/model/ComponentFilter;
-	public final fun getPassword ()Ljava/lang/String;
-	public final fun getUrl ()Ljava/lang/String;
-	public final fun getUser ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun withComponentFilter (Lkotlin/jvm/functions/Function1;)Lcom/deezer/caupain/model/Repository;
-}
-
-public final class com/deezer/caupain/model/Repository$Companion {
-}
-
-public final class com/deezer/caupain/model/RepositoryKt {
+public final class com/deezer/caupain/model/Repositories {
+	public static final fun Repository (Ljava/lang/String;)Lcom/deezer/caupain/model/Repository;
+	public static final fun Repository (Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;)Lcom/deezer/caupain/model/Repository;
+	public static final fun Repository (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/deezer/caupain/model/Repository;
+	public static final fun Repository (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;)Lcom/deezer/caupain/model/Repository;
+	public static synthetic fun Repository$default (Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;ILjava/lang/Object;)Lcom/deezer/caupain/model/Repository;
+	public static synthetic fun Repository$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/deezer/caupain/model/ComponentFilter;ILjava/lang/Object;)Lcom/deezer/caupain/model/Repository;
 	public static final fun buildComponentFilter (Lkotlin/jvm/functions/Function1;)Lcom/deezer/caupain/model/ComponentFilter;
+	public static final fun withComponentFilter (Lcom/deezer/caupain/model/Repository;Lkotlin/jvm/functions/Function1;)Lcom/deezer/caupain/model/Repository;
+}
+
+public abstract interface class com/deezer/caupain/model/Repository : java/io/Serializable {
+	public abstract fun contains (Lcom/deezer/caupain/model/Dependency;)Z
+	public abstract fun getPassword ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+	public abstract fun getUser ()Ljava/lang/String;
 }
 
 public final class com/deezer/caupain/model/StabilityLevelPolicy : com/deezer/caupain/model/Policy {

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -73,6 +73,17 @@ abstract interface com.deezer.caupain.model/Policy { // com.deezer.caupain.model
     abstract fun select(com.deezer.caupain.model/Dependency, com.deezer.caupain.model.versionCatalog/Version.Resolved, com.deezer.caupain.model/GradleDependencyVersion.Static): kotlin/Boolean // com.deezer.caupain.model/Policy.select|select(com.deezer.caupain.model.Dependency;com.deezer.caupain.model.versionCatalog.Version.Resolved;com.deezer.caupain.model.GradleDependencyVersion.Static){}[0]
 }
 
+abstract interface com.deezer.caupain.model/Repository : com.deezer.caupain/Serializable { // com.deezer.caupain.model/Repository|null[0]
+    abstract val password // com.deezer.caupain.model/Repository.password|{}password[0]
+        abstract fun <get-password>(): kotlin/String? // com.deezer.caupain.model/Repository.password.<get-password>|<get-password>(){}[0]
+    abstract val url // com.deezer.caupain.model/Repository.url|{}url[0]
+        abstract fun <get-url>(): kotlin/String // com.deezer.caupain.model/Repository.url.<get-url>|<get-url>(){}[0]
+    abstract val user // com.deezer.caupain.model/Repository.user|{}user[0]
+        abstract fun <get-user>(): kotlin/String? // com.deezer.caupain.model/Repository.user.<get-user>|<get-user>(){}[0]
+
+    abstract fun contains(com.deezer.caupain.model/Dependency): kotlin/Boolean // com.deezer.caupain.model/Repository.contains|contains(com.deezer.caupain.model.Dependency){}[0]
+}
+
 abstract interface com.deezer.caupain/DependencyUpdateChecker { // com.deezer.caupain/DependencyUpdateChecker|null[0]
     abstract val progress // com.deezer.caupain/DependencyUpdateChecker.progress|{}progress[0]
         abstract fun <get-progress>(): kotlinx.coroutines.flow/Flow<com.deezer.caupain/DependencyUpdateChecker.Progress?> // com.deezer.caupain/DependencyUpdateChecker.progress.<get-progress>|<get-progress>(){}[0]
@@ -518,28 +529,6 @@ final class com.deezer.caupain.model/PluginExclusion : com.deezer.caupain.model/
     final fun toString(): kotlin/String // com.deezer.caupain.model/PluginExclusion.toString|toString(){}[0]
 }
 
-final class com.deezer.caupain.model/Repository : com.deezer.caupain/Serializable { // com.deezer.caupain.model/Repository|null[0]
-    constructor <init>(kotlin/String, com.deezer.caupain.model/ComponentFilter? = ...) // com.deezer.caupain.model/Repository.<init>|<init>(kotlin.String;com.deezer.caupain.model.ComponentFilter?){}[0]
-    constructor <init>(kotlin/String, kotlin/String?, kotlin/String?, com.deezer.caupain.model/ComponentFilter? = ...) // com.deezer.caupain.model/Repository.<init>|<init>(kotlin.String;kotlin.String?;kotlin.String?;com.deezer.caupain.model.ComponentFilter?){}[0]
-
-    final val componentFilter // com.deezer.caupain.model/Repository.componentFilter|{}componentFilter[0]
-        final fun <get-componentFilter>(): com.deezer.caupain.model/ComponentFilter? // com.deezer.caupain.model/Repository.componentFilter.<get-componentFilter>|<get-componentFilter>(){}[0]
-    final val password // com.deezer.caupain.model/Repository.password|{}password[0]
-        final fun <get-password>(): kotlin/String? // com.deezer.caupain.model/Repository.password.<get-password>|<get-password>(){}[0]
-    final val url // com.deezer.caupain.model/Repository.url|{}url[0]
-        final fun <get-url>(): kotlin/String // com.deezer.caupain.model/Repository.url.<get-url>|<get-url>(){}[0]
-    final val user // com.deezer.caupain.model/Repository.user|{}user[0]
-        final fun <get-user>(): kotlin/String? // com.deezer.caupain.model/Repository.user.<get-user>|<get-user>(){}[0]
-
-    final fun contains(com.deezer.caupain.model/Dependency): kotlin/Boolean // com.deezer.caupain.model/Repository.contains|contains(com.deezer.caupain.model.Dependency){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // com.deezer.caupain.model/Repository.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // com.deezer.caupain.model/Repository.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // com.deezer.caupain.model/Repository.toString|toString(){}[0]
-    final inline fun withComponentFilter(kotlin/Function1<com.deezer.caupain.model/ComponentFilterBuilder, kotlin/Unit>): com.deezer.caupain.model/Repository // com.deezer.caupain.model/Repository.withComponentFilter|withComponentFilter(kotlin.Function1<com.deezer.caupain.model.ComponentFilterBuilder,kotlin.Unit>){}[0]
-
-    final object Companion // com.deezer.caupain.model/Repository.Companion|null[0]
-}
-
 final class com.deezer.caupain.model/UpdateInfo { // com.deezer.caupain.model/UpdateInfo|null[0]
     constructor <init>(kotlin/String, kotlin/String, kotlin/String? = ..., kotlin/String? = ..., kotlin/String, kotlin/String) // com.deezer.caupain.model/UpdateInfo.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String;kotlin.String){}[0]
 
@@ -601,5 +590,8 @@ final object com.deezer.caupain.model/StabilityLevelPolicy : com.deezer.caupain.
 final fun com.deezer.caupain.model/Configuration(kotlin.collections/List<com.deezer.caupain.model/Repository> = ..., kotlin.collections/List<com.deezer.caupain.model/Repository> = ..., kotlin.collections/Iterable<okio/Path> = ..., kotlin.collections/Set<kotlin/String> = ..., kotlin.collections/List<com.deezer.caupain.model/LibraryExclusion> = ..., kotlin.collections/List<com.deezer.caupain.model/PluginExclusion> = ..., kotlin/String? = ..., okio/Path? = ..., okio/Path? = ..., kotlin/Boolean = ..., kotlin/String = ..., kotlin/Boolean = ...): com.deezer.caupain.model/Configuration // com.deezer.caupain.model/Configuration|Configuration(kotlin.collections.List<com.deezer.caupain.model.Repository>;kotlin.collections.List<com.deezer.caupain.model.Repository>;kotlin.collections.Iterable<okio.Path>;kotlin.collections.Set<kotlin.String>;kotlin.collections.List<com.deezer.caupain.model.LibraryExclusion>;kotlin.collections.List<com.deezer.caupain.model.PluginExclusion>;kotlin.String?;okio.Path?;okio.Path?;kotlin.Boolean;kotlin.String;kotlin.Boolean){}[0]
 final fun com.deezer.caupain.model/Configuration(kotlin.collections/List<com.deezer.caupain.model/Repository> = ..., kotlin.collections/List<com.deezer.caupain.model/Repository> = ..., okio/Path, kotlin.collections/Set<kotlin/String> = ..., kotlin.collections/List<com.deezer.caupain.model/LibraryExclusion> = ..., kotlin.collections/List<com.deezer.caupain.model/PluginExclusion> = ..., kotlin/String? = ..., okio/Path? = ..., okio/Path? = ..., kotlin/Boolean = ..., kotlin/String = ..., kotlin/Boolean = ...): com.deezer.caupain.model/Configuration // com.deezer.caupain.model/Configuration|Configuration(kotlin.collections.List<com.deezer.caupain.model.Repository>;kotlin.collections.List<com.deezer.caupain.model.Repository>;okio.Path;kotlin.collections.Set<kotlin.String>;kotlin.collections.List<com.deezer.caupain.model.LibraryExclusion>;kotlin.collections.List<com.deezer.caupain.model.PluginExclusion>;kotlin.String?;okio.Path?;okio.Path?;kotlin.Boolean;kotlin.String;kotlin.Boolean){}[0]
 final fun com.deezer.caupain.model/GradleDependencyVersion(kotlin/String): com.deezer.caupain.model/GradleDependencyVersion // com.deezer.caupain.model/GradleDependencyVersion|GradleDependencyVersion(kotlin.String){}[0]
+final fun com.deezer.caupain.model/Repository(kotlin/String, com.deezer.caupain.model/ComponentFilter? = ...): com.deezer.caupain.model/Repository // com.deezer.caupain.model/Repository|Repository(kotlin.String;com.deezer.caupain.model.ComponentFilter?){}[0]
+final fun com.deezer.caupain.model/Repository(kotlin/String, kotlin/String?, kotlin/String?, com.deezer.caupain.model/ComponentFilter? = ...): com.deezer.caupain.model/Repository // com.deezer.caupain.model/Repository|Repository(kotlin.String;kotlin.String?;kotlin.String?;com.deezer.caupain.model.ComponentFilter?){}[0]
 final fun com.deezer.caupain/DependencyUpdateChecker(com.deezer.caupain.model/Configuration, kotlin/String?, com.deezer.caupain.model/Logger = ..., okio/FileSystem = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlin.collections/List<com.deezer.caupain.model/Policy>? = ...): com.deezer.caupain/DependencyUpdateChecker // com.deezer.caupain/DependencyUpdateChecker|DependencyUpdateChecker(com.deezer.caupain.model.Configuration;kotlin.String?;com.deezer.caupain.model.Logger;okio.FileSystem;kotlinx.coroutines.CoroutineDispatcher;kotlin.collections.List<com.deezer.caupain.model.Policy>?){}[0]
+final inline fun (com.deezer.caupain.model/Repository).com.deezer.caupain.model/withComponentFilter(kotlin/Function1<com.deezer.caupain.model/ComponentFilterBuilder, kotlin/Unit>): com.deezer.caupain.model/Repository // com.deezer.caupain.model/withComponentFilter|withComponentFilter@com.deezer.caupain.model.Repository(kotlin.Function1<com.deezer.caupain.model.ComponentFilterBuilder,kotlin.Unit>){}[0]
 final inline fun com.deezer.caupain.model/buildComponentFilter(kotlin/Function1<com.deezer.caupain.model/ComponentFilterBuilder, kotlin/Unit>): com.deezer.caupain.model/ComponentFilter // com.deezer.caupain.model/buildComponentFilter|buildComponentFilter(kotlin.Function1<com.deezer.caupain.model.ComponentFilterBuilder,kotlin.Unit>){}[0]

--- a/core/src/commonMain/kotlin/com/deezer/caupain/model/Configuration.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/model/Configuration.kt
@@ -21,12 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@file:JvmName("Configurations")
 
 package com.deezer.caupain.model
 
 import com.deezer.caupain.Serializable
 import okio.Path
 import okio.Path.Companion.toPath
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 
 /**
  * Configuration is a data class that holds the configuration for the dependency update process.
@@ -47,6 +50,7 @@ import okio.Path.Companion.toPath
 public interface Configuration : Serializable {
     public val repositories: List<Repository>
     public val pluginRepositories: List<Repository>
+
     @Deprecated("Use versionCatalogPaths instead")
     public val versionCatalogPath: Path
     public val versionCatalogPaths: Iterable<Path>
@@ -84,6 +88,7 @@ public interface Configuration : Serializable {
  * @param onlyCheckStaticVersions Whether to only check updates for static versions or all versions.
  */
 @Suppress("LongParameterList") // Needed to reflect parameters
+@JvmOverloads
 public fun Configuration(
     repositories: List<Repository> = listOf(
         DefaultRepositories.mavenCentral,
@@ -136,6 +141,7 @@ public fun Configuration(
  * @param onlyCheckStaticVersions Whether to only check updates for static versions or all versions.
  */
 @Suppress("LongParameterList") // Needed to reflect parameters
+@JvmOverloads
 public fun Configuration(
     repositories: List<Repository> = listOf(
         DefaultRepositories.mavenCentral,

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -87,7 +87,8 @@ my-regular-plugin = { id = "com.example.plugin", version.ref = "my-regular-ref" 
 ### Repositories
 
 By default, the Maven repositories that are used are the ones defined in the the `pluginManagement`
-and `dependencyResolutionManagement` of your `settings.gradle.kts` file. If you want to override these,
+and `dependencyResolutionManagement` of your `settings.gradle.kts` file, plus the ones defined in the 
+`repositories` or `buildScript.repositories` of the projects. If you want to override these,
 you can use the following syntax:
 ```kotlin
 repositories {

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -125,9 +125,9 @@ public final class com/deezer/caupain/plugin/RepositoryCategoryHandler {
 }
 
 public abstract class com/deezer/caupain/plugin/RepositoryHandler {
-	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/invocation/Gradle;)V
-	public final fun getLibraries ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getPlugins ()Lorg/gradle/api/provider/ListProperty;
+	public fun <init> ()V
+	public abstract fun getLibraries ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getPlugins ()Lorg/gradle/api/provider/ListProperty;
 	public final fun libraries (Lorg/gradle/api/Action;)V
 	public final fun plugins (Lorg/gradle/api/Action;)V
 }

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/RepositoryHandler.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/RepositoryHandler.kt
@@ -26,54 +26,29 @@
 
 package com.deezer.caupain.plugin
 
-import com.deezer.caupain.model.ComponentFilter
 import com.deezer.caupain.model.ComponentFilterBuilder
-import com.deezer.caupain.model.Dependency
-import com.deezer.caupain.model.Dependency.Library
-import com.deezer.caupain.model.Dependency.Plugin
 import com.deezer.caupain.model.Repository
 import com.deezer.caupain.model.buildComponentFilter
-import com.deezer.caupain.plugin.internal.asOptional
+import com.deezer.caupain.model.withComponentFilter
 import org.gradle.api.Action
-import org.gradle.api.artifacts.ModuleIdentifier
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.gradle.api.artifacts.repositories.PasswordCredentials
-import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails
-import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository
-import org.gradle.api.invocation.Gradle
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
-import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal
-import org.gradle.kotlin.dsl.listProperty
-import javax.inject.Inject
-import kotlin.jvm.optionals.getOrNull
 
 /**
  * Repository handler for easy configuration
  */
 @Suppress("UnnecessaryAbstractClass") // Needed by Gradle
-abstract class RepositoryHandler @Inject constructor(
-    objects: ObjectFactory,
-    gradle: Gradle
-) {
+abstract class RepositoryHandler {
 
     /**
      * Libraries repositories to check for updates.
      */
-    val libraries: ListProperty<Repository> = objects.listProperty<Repository>().convention(
-        gradle.dependenciesRepositoryHandler.toRepositories(objects)
-    )
+    abstract val libraries: ListProperty<Repository>
 
     /**
      * Plugin repositories
      */
-    val plugins: ListProperty<Repository> = objects.listProperty<Repository>().convention(
-        gradle.pluginsRepositoryHandler.toRepositories(objects)
-    )
+    abstract val plugins: ListProperty<Repository>
 
     fun libraries(action: Action<RepositoryCategoryHandler>) {
         action.execute(RepositoryCategoryHandler(libraries))
@@ -82,118 +57,13 @@ abstract class RepositoryHandler @Inject constructor(
     fun plugins(action: Action<RepositoryCategoryHandler>) {
         action.execute(RepositoryCategoryHandler(plugins))
     }
-}
 
-private val Gradle.dependenciesRepositoryHandler: RepositoryHandler
-    get() = (this as GradleInternal).settings.dependencyResolutionManagement.repositories
-
-private val Gradle.pluginsRepositoryHandler: RepositoryHandler
-    get() = (this as GradleInternal).settings.pluginManagement.repositories
-
-private val ACCEPTED_SCHEMES = setOf("http", "https")
-
-private fun RepositoryHandler.toRepositories(objects: ObjectFactory): Provider<List<Repository>> {
-    val repositoriesProvider = objects.listProperty<Repository>()
-    for (repository in this) {
-        if (repository is MavenArtifactRepository && repository.url.scheme in ACCEPTED_SCHEMES) {
-            val url = repository.url.toString()
-            val credentials =
-                (repository as? AuthenticationSupportedInternal)?.configuredCredentials
-            val filter = (repository as? ContentFilteringRepository)?.contentFilter
-            if (credentials == null) {
-                repositoriesProvider.add(
-                    Repository(
-                        url = url,
-                        componentFilter = filter?.let(::ComponentFilterAdapter)
-                    )
-                )
-            } else {
-                repositoriesProvider.add(
-                    credentials
-                        .asOptional()
-                        .map { optionalCredentials ->
-                            val passwordCredentials =
-                                optionalCredentials.getOrNull() as? PasswordCredentials
-                            Repository(
-                                url = url,
-                                user = passwordCredentials?.username,
-                                password = passwordCredentials?.password,
-                                componentFilter = filter?.let(::ComponentFilterAdapter)
-                            )
-                        }
-                )
-            }
-        }
-    }
-    return repositoriesProvider
-}
-
-private class ComponentFilterAdapter(private val filter: Action<in ArtifactResolutionDetails>) :
-    ComponentFilter {
-
-    override fun accepts(dependency: Dependency): Boolean {
-        if (dependency.group == null || dependency.name == null) return false
-        return ArtifactResolutionDetailsAdapter(dependency)
-            .apply { filter.execute(this) }
-            .isFound
-    }
-
-    private class ModuleIdentifierAdapter(private val dependency: Dependency) : ModuleIdentifier {
-        override fun getGroup(): String = requireNotNull(dependency.group)
-
-        override fun getName(): String = requireNotNull(dependency.name)
-    }
-
-    private class ModuleComponentIdentifierAdapter(private val dependency: Dependency) :
-        ModuleComponentIdentifier {
-        private val identifier = ModuleIdentifierAdapter(dependency)
-
-        override fun getDisplayName(): String = dependency.moduleId
-
-        override fun getGroup(): String = identifier.group
-
-        override fun getModule(): String = identifier.name
-
-        override fun getVersion(): String = requireNotNull(dependency.version).toString()
-
-        override fun getModuleIdentifier(): ModuleIdentifier = identifier
-    }
-
-    private class ArtifactResolutionDetailsAdapter(
-        private val dependency: Dependency
-    ) : ArtifactResolutionDetails {
-
-        var isFound = true
-            private set
-
-        override fun getModuleId(): ModuleIdentifier = ModuleIdentifierAdapter(dependency)
-
-        override fun getComponentId(): ModuleComponentIdentifier? =
-            if (dependency.version == null) {
-                null
-            } else {
-                ModuleComponentIdentifierAdapter(dependency)
-            }
-
-        override fun isVersionListing(): Boolean = dependency.version != null
-
-        override fun notFound() {
-            isFound = false
-        }
-    }
-
-    companion object {
-        private val Dependency.group: String?
-            get() = when (this) {
-                is Library -> group
-                is Plugin -> id
-            }
-
-        private val Dependency.name: String?
-            get() = when (this) {
-                is Library -> name
-                is Plugin -> "$id.gradle.plugin"
-            }
+    internal fun setupConvention(
+        libraryRepositories: Provider<out Iterable<Repository>>,
+        pluginRepositories: Provider<out Iterable<Repository>>
+    ) {
+        libraries.convention(libraryRepositories)
+        plugins.convention(pluginRepositories)
     }
 }
 

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/internal/repositories.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/internal/repositories.kt
@@ -1,0 +1,163 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Deezer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.deezer.caupain.plugin.internal
+
+import com.deezer.caupain.model.Dependency
+import com.deezer.caupain.model.Dependency.Library
+import com.deezer.caupain.model.Dependency.Plugin
+import com.deezer.caupain.model.Repository
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails
+import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal
+import org.gradle.kotlin.dsl.listProperty
+import kotlin.jvm.optionals.getOrNull
+
+private val ACCEPTED_SCHEMES = setOf("http", "https")
+
+internal fun RepositoryHandler.toRepositories(objects: ObjectFactory): Provider<List<Repository>> {
+    val repositoriesProvider = objects.listProperty<Repository>()
+    for (repository in this) {
+        if (repository is MavenArtifactRepository && repository.url.scheme in ACCEPTED_SCHEMES) {
+            val credentials =
+                (repository as? AuthenticationSupportedInternal)?.configuredCredentials
+            if (credentials == null) {
+                repositoriesProvider.add(RepositoryDelegate(repository))
+            } else {
+                repositoriesProvider.add(
+                    credentials
+                        .asOptional()
+                        .map { optionalCredentials ->
+                            RepositoryDelegate(
+                                delegate = repository,
+                                credentials = optionalCredentials.getOrNull() as? PasswordCredentials
+                            )
+                        }
+                )
+            }
+        }
+    }
+    return repositoriesProvider
+}
+
+private data class RepositoryDelegate(
+    private val delegate: MavenArtifactRepository,
+    private val credentials: PasswordCredentials? = null,
+) : Repository {
+
+    private val filterAction by lazy { (delegate as? ContentFilteringRepository)?.contentFilter }
+
+    override val url: String
+        get() = delegate.url.toString()
+
+    override val user: String?
+        get() = credentials?.username
+
+    override val password: String?
+        get() = credentials?.password
+
+    override fun contains(dependency: Dependency): Boolean {
+        val action = filterAction ?: return true
+        if (dependency.group == null || dependency.name == null) return false
+        return ArtifactResolutionDetailsAdapter(dependency)
+            .apply { action.execute(this) }
+            .isFound
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RepositoryDelegate
+
+        return delegate == other.delegate
+    }
+
+    override fun hashCode(): Int {
+        return delegate.hashCode()
+    }
+}
+
+private class ModuleIdentifierAdapter(private val dependency: Dependency) : ModuleIdentifier {
+    override fun getGroup(): String = requireNotNull(dependency.group)
+
+    override fun getName(): String = requireNotNull(dependency.name)
+}
+
+private class ModuleComponentIdentifierAdapter(private val dependency: Dependency) :
+    ModuleComponentIdentifier {
+    private val identifier = ModuleIdentifierAdapter(dependency)
+
+    override fun getDisplayName(): String = dependency.moduleId
+
+    override fun getGroup(): String = identifier.group
+
+    override fun getModule(): String = identifier.name
+
+    override fun getVersion(): String = requireNotNull(dependency.version).toString()
+
+    override fun getModuleIdentifier(): ModuleIdentifier = identifier
+}
+
+private class ArtifactResolutionDetailsAdapter(
+    private val dependency: Dependency
+) : ArtifactResolutionDetails {
+
+    var isFound = true
+        private set
+
+    override fun getModuleId(): ModuleIdentifier = ModuleIdentifierAdapter(dependency)
+
+    override fun getComponentId(): ModuleComponentIdentifier? =
+        if (dependency.version == null) {
+            null
+        } else {
+            ModuleComponentIdentifierAdapter(dependency)
+        }
+
+    override fun isVersionListing(): Boolean = dependency.version != null
+
+    override fun notFound() {
+        isFound = false
+    }
+}
+
+private val Dependency.group: String?
+    get() = when (this) {
+        is Library -> group
+        is Plugin -> id
+    }
+
+private val Dependency.name: String?
+    get() = when (this) {
+        is Library -> name
+        is Plugin -> "$id.gradle.plugin"
+    }


### PR DESCRIPTION
## What does this PR do?

Improves the Gradle plugin by using the repositories defined in the project as default, adding to those configured in the settings file.

This also transforms `Repository` into an interface to allow for delegate implementation on the Gradle plugin side.

## Checklist
- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.