### PR TITLE
Specify CA cert path for Linux ARM64

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -45,7 +45,9 @@ kotlin {
         linuxArm64()
         jvm()
 
-        getByName("commonMain") {
+        applyDefaultHierarchyTemplate()
+
+        commonMain {
             kotlin {
                 srcDir(layout.buildDirectory.dir("generated-src/antlr"))
             }
@@ -67,7 +69,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json.okio)
             }
         }
-        getByName("commonTest") {
+        commonTest {
             dependencies {
                 implementation(libs.kotlin.test)
                 implementation(libs.okio.fake.filesystem)
@@ -78,33 +80,40 @@ kotlin {
                 implementation(libs.ktor.client.cio)
             }
         }
-        getByName("jvmMain") {
+        val nonLinuxArm64Main by creating {
+            dependsOn(commonMain.get())
+        }
+        jvmMain {
+            dependsOn(nonLinuxArm64Main)
             dependencies {
                 implementation(libs.slf4j.nop)
                 implementation(libs.ktor.client.okhttp)
             }
         }
-        getByName("jvmTest") {
+        jvmTest {
             dependencies {
                 implementation(libs.kotlin.test.junit)
                 implementation(libs.junit)
             }
         }
-        create("macosMain") {
+        macosMain {
+            dependsOn(nonLinuxArm64Main)
             dependencies {
                 implementation(libs.ktor.client.darwin)
             }
         }
-        create("mingwMain") {
+        mingwMain {
+            dependsOn(nonLinuxArm64Main)
             dependencies {
                 implementation(libs.ktor.client.winhttp)
             }
         }
-        create("linuxMain") {
+        linuxMain {
             dependencies {
                 implementation(libs.ktor.client.curl)
             }
         }
+        linuxX64Main.get().dependsOn(nonLinuxArm64Main)
     }
 }
 

--- a/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
@@ -29,6 +29,7 @@ import com.deezer.caupain.DependencyUpdateChecker.Companion.FINDING_UPDATES_TASK
 import com.deezer.caupain.DependencyUpdateChecker.Companion.GATHERING_INFO_TASK
 import com.deezer.caupain.DependencyUpdateChecker.Companion.PARSING_TASK
 import com.deezer.caupain.internal.FileStorage
+import com.deezer.caupain.internal.configureKtorEngine
 import com.deezer.caupain.internal.extension
 import com.deezer.caupain.model.Configuration
 import com.deezer.caupain.model.DEFAULT_POLICIES
@@ -212,6 +213,9 @@ public fun DependencyUpdateChecker(
     currentGradleVersion = currentGradleVersion,
     fileSystem = fileSystem,
     httpClient = HttpClient {
+        engine {
+            configureKtorEngine()
+        }
         install(ContentNegotiation) {
             json(DefaultJson)
             xml(DefaultXml, ContentType.Any)

--- a/core/src/commonMain/kotlin/com/deezer/caupain/internal/http.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/internal/http.kt
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Deezer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.deezer.caupain.internal
+
+import io.ktor.client.engine.HttpClientEngineConfig
+
+internal expect fun HttpClientEngineConfig.configureKtorEngine()

--- a/core/src/linuxArm64Main/kotlin/com/deezer/caupain/internal/SpecificKtorEngineConfig.kt
+++ b/core/src/linuxArm64Main/kotlin/com/deezer/caupain/internal/SpecificKtorEngineConfig.kt
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Deezer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.deezer.caupain.internal
+
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.curl.CurlClientEngineConfig
+
+internal actual fun HttpClientEngineConfig.configureKtorEngine() {
+    if (this is CurlClientEngineConfig) {
+        // Set up the CA path for Curl because of https://youtrack.jetbrains.com/issue/KTOR-8339
+        caPath = caPath ?: "/etc/ssl/certs"
+    }
+}

--- a/core/src/linuxArm64Main/kotlin/com/deezer/caupain/internal/SpecificKtorEngineConfig.kt
+++ b/core/src/linuxArm64Main/kotlin/com/deezer/caupain/internal/SpecificKtorEngineConfig.kt
@@ -30,6 +30,6 @@ import io.ktor.client.engine.curl.CurlClientEngineConfig
 internal actual fun HttpClientEngineConfig.configureKtorEngine() {
     if (this is CurlClientEngineConfig) {
         // Set up the CA path for Curl because of https://youtrack.jetbrains.com/issue/KTOR-8339
-        caPath = caPath ?: "/etc/ssl/certs"
+        caPath = "/etc/ssl/certs"
     }
 }

--- a/core/src/nonLinuxArm64Main/kotlin/com/deezer/caupain/internal/DefaultKtorEngineConfig.kt
+++ b/core/src/nonLinuxArm64Main/kotlin/com/deezer/caupain/internal/DefaultKtorEngineConfig.kt
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Deezer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.deezer.caupain.internal
+
+import io.ktor.client.engine.HttpClientEngineConfig
+
+internal actual fun HttpClientEngineConfig.configureKtorEngine() {
+    // This is a placeholder for non-Linux ARM64 platforms.
+}


### PR DESCRIPTION
## What does this PR do?

Due to [this Ktor issue](https://youtrack.jetbrains.com/issue/KTOR-8339), SSL does not work in some cases on Linux ARM64. Following the workaround in the issue, this PR specifies the CA cert path for Linux ARM64. This will need to be removed at one point once Ktor builds the curl lib correctly.

## Issue number, if applicable

Fixes #30 

## Checklist
- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.