### PR TITLE
Feat/do not check self updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Feature to filter selected versions in the configuration with a Maven-like pattern (#85)
 - Include options in configuration (#86)
+- CLI flag `--do-not-check-self-updates` to skip the GitHub self-update check (#89)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature to filter selected versions in the configuration with a Maven-like pattern (#85)
 - Include options in configuration (#86)
 - CLI flag `--do-not-check-self-updates` and TOML option to skip the GitHub self-update check (#89)
+- Gradle plugin `doNotCheckSelfUpdates` option to skip self-update check (#89)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Feature to filter selected versions in the configuration with a Maven-like pattern (#85)
 - Include options in configuration (#86)
-- CLI flag `--do-not-check-self-updates` to skip the GitHub self-update check (#89)
+- CLI flag `--do-not-check-self-updates` and TOML option to skip the GitHub self-update check (#89)
 
 ### Changed
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -195,6 +195,8 @@ searchReleaseNotes = true
 # Note: This may slow down the checking process as it adds extra network requests.
 # Default is false.
 verifyExistence = true
+# Whether to skip the GitHub self-update check. Default is false.
+doNotCheckSelfUpdates = true
 ```
 
 #### Repository component filtering

--- a/cli/README.md
+++ b/cli/README.md
@@ -98,6 +98,7 @@ Options:
   --debug-http-calls            Enable debugging for HTTP calls
   --verify-existence            Verify that .pom file exists before accepting
                                 version updates (warning: may slow down checks)
+  --do-not-check-self-updates   Do not check for Caupain updates on GitHub
   --version                     Show the version and exit
   -h, --help                    Show this message and exit
 ```

--- a/cli/completions/bash-completion.sh
+++ b/cli/completions/bash-completion.sh
@@ -170,6 +170,11 @@ _caupain() {
           in_param=''
           continue
           ;;
+        --do-not-check-self-updates)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
         --version)
           __skip_opt_eq
           in_param=''
@@ -192,7 +197,7 @@ _caupain() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '-i --version-catalog --gradle-wrapper-properties -e --excluded -c --config --policy-plugin-dir -p --policy --list-policies --gradle-stability-level -t --output-type -o --output --output-dir --output-base-name --show-version-references --in-place --github-token --search-release-notes --cache-dir --no-cache --clean-cache -q --quiet -v --verbose -d --debug --debug-http-calls --verify-existence --version -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '-i --version-catalog --gradle-wrapper-properties -e --excluded -c --config --policy-plugin-dir -p --policy --list-policies --gradle-stability-level -t --output-type -o --output --output-dir --output-base-name --show-version-references --in-place --github-token --search-release-notes --cache-dir --no-cache --clean-cache -q --quiet -v --verbose -d --debug --debug-http-calls --verify-existence --do-not-check-self-updates --version -h --help' -- "${word}"))
     return
   fi
 
@@ -258,6 +263,8 @@ _caupain() {
     "--debug-http-calls")
       ;;
     "--verify-existence")
+      ;;
+    "--do-not-check-self-updates")
       ;;
     "--version")
       ;;

--- a/cli/completions/fish-completion.sh
+++ b/cli/completions/fish-completion.sh
@@ -26,6 +26,7 @@ complete -c caupain -s v -l verbose -d 'Verbose output'
 complete -c caupain -s d -l debug -d 'Debug output'
 complete -c caupain -l debug-http-calls -d 'Enable debugging for HTTP calls'
 complete -c caupain -l verify-existence -d 'Verify that .pom file exists before accepting version updates (warning: may slow down checks)'
+complete -c caupain -l do-not-check-self-updates -d 'Do not check for Caupain updates on GitHub'
 complete -c caupain -l version -d 'Show the version and exit'
 complete -c caupain -s h -l help -d 'Show this message and exit'
 

--- a/cli/completions/zsh-completion.sh
+++ b/cli/completions/zsh-completion.sh
@@ -175,6 +175,11 @@ _caupain() {
           in_param=''
           continue
           ;;
+        --do-not-check-self-updates)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
         --version)
           __skip_opt_eq
           in_param=''
@@ -197,7 +202,7 @@ _caupain() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '-i --version-catalog --gradle-wrapper-properties -e --excluded -c --config --policy-plugin-dir -p --policy --list-policies --gradle-stability-level -t --output-type -o --output --output-dir --output-base-name --show-version-references --in-place --github-token --search-release-notes --cache-dir --no-cache --clean-cache -q --quiet -v --verbose -d --debug --debug-http-calls --verify-existence --version -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '-i --version-catalog --gradle-wrapper-properties -e --excluded -c --config --policy-plugin-dir -p --policy --list-policies --gradle-stability-level -t --output-type -o --output --output-dir --output-base-name --show-version-references --in-place --github-token --search-release-notes --cache-dir --no-cache --clean-cache -q --quiet -v --verbose -d --debug --debug-http-calls --verify-existence --do-not-check-self-updates --version -h --help' -- "${word}"))
     return
   fi
 
@@ -263,6 +268,8 @@ _caupain() {
     "--debug-http-calls")
       ;;
     "--verify-existence")
+      ;;
+    "--do-not-check-self-updates")
       ;;
     "--version")
       ;;

--- a/cli/src/commonMain/kotlin/com/deezer/caupain/cli/CaupainCLI.kt
+++ b/cli/src/commonMain/kotlin/com/deezer/caupain/cli/CaupainCLI.kt
@@ -295,7 +295,7 @@ class CaupainCLI(
                     fileSystem,
                     ioDispatcher,
                     logger,
-                    if (doNotCheckSelfUpdates) {
+                    if (shouldNotCheckSelfUpdates(configuration)) {
                         null
                     } else {
                         CLISelfUpdateResolver(
@@ -495,6 +495,9 @@ class CaupainCLI(
             verifyExistence = verifyExistence || parsedConfiguration?.verifyExistence == true
         )
     }
+
+    private fun shouldNotCheckSelfUpdates(parsedConfiguration: ParsedConfiguration?): Boolean =
+        doNotCheckSelfUpdates || parsedConfiguration?.doNotCheckSelfUpdates == true
 
     private fun validateConfiguration(
         parsedConfiguration: ParsedConfiguration?,

--- a/cli/src/commonMain/kotlin/com/deezer/caupain/cli/CaupainCLI.kt
+++ b/cli/src/commonMain/kotlin/com/deezer/caupain/cli/CaupainCLI.kt
@@ -109,7 +109,7 @@ class CaupainCLI(
         DefaultToml.decodeFromPath(path, fs)
     },
     @Suppress("NoNameShadowing") // Ok to repeat here for clarity
-    private val createUpdateChecker: (Configuration, String?, FileSystem, CoroutineDispatcher, Logger, SelfUpdateResolver) -> DependencyUpdateChecker = { config, gradleVersion, fs, ioDispatcher, logger, selfUpdateResolver ->
+    private val createUpdateChecker: (Configuration, String?, FileSystem, CoroutineDispatcher, Logger, SelfUpdateResolver?) -> DependencyUpdateChecker = { config, gradleVersion, fs, ioDispatcher, logger, selfUpdateResolver ->
         DependencyUpdateChecker(
             configuration = config,
             currentGradleVersion = gradleVersion,
@@ -247,6 +247,11 @@ class CaupainCLI(
         help = "Verify that .pom file exists before accepting version updates (warning: may slow down checks)"
     ).flag()
 
+    private val doNotCheckSelfUpdates by option(
+        "--do-not-check-self-updates",
+        help = "Do not check for Caupain updates on GitHub",
+    ).flag()
+
     private val timesource = TimeSource.Monotonic
 
     init {
@@ -290,12 +295,16 @@ class CaupainCLI(
                     fileSystem,
                     ioDispatcher,
                     logger,
-                    CLISelfUpdateResolver(
-                        logger = logger,
-                        ioDispatcher = ioDispatcher,
-                        fileSystem = fileSystem,
-                        githubToken = finalConfiguration.githubToken
-                    )
+                    if (doNotCheckSelfUpdates) {
+                        null
+                    } else {
+                        CLISelfUpdateResolver(
+                            logger = logger,
+                            ioDispatcher = ioDispatcher,
+                            fileSystem = fileSystem,
+                            githubToken = finalConfiguration.githubToken
+                        )
+                    }
                 )
 
             if (listPolicies) {

--- a/cli/src/commonMain/kotlin/com/deezer/caupain/cli/model/Configuration.kt
+++ b/cli/src/commonMain/kotlin/com/deezer/caupain/cli/model/Configuration.kt
@@ -65,6 +65,7 @@ interface Configuration {
     val searchReleaseNote: Boolean?
     val githubToken: String?
     val verifyExistence: Boolean?
+    val doNotCheckSelfUpdates: Boolean?
 
     fun validate(logger: Logger)
 

--- a/cli/src/commonMain/kotlin/com/deezer/caupain/cli/serialization/Configuration.kt
+++ b/cli/src/commonMain/kotlin/com/deezer/caupain/cli/serialization/Configuration.kt
@@ -84,7 +84,8 @@ private data class ConfigurationImpl(
     override val checkIgnored: Boolean? = null,
     override val githubToken: String? = null,
     override val searchReleaseNote: Boolean? = null,
-    override val verifyExistence: Boolean? = null
+    override val verifyExistence: Boolean? = null,
+    override val doNotCheckSelfUpdates: Boolean? = null,
 ) : Configuration {
 
     override fun validate(logger: Logger) {

--- a/cli/src/commonTest/kotlin/com/deezer/caupain/cli/CaupainCLITest.kt
+++ b/cli/src/commonTest/kotlin/com/deezer/caupain/cli/CaupainCLITest.kt
@@ -250,6 +250,48 @@ class CaupainCLITest {
     }
 
     @Test
+    fun testDoNotCheckSelfUpdatesFromConfig() {
+        runTest(testDispatcher) {
+            everySuspend { checker.checkForUpdates() } returns DependenciesUpdateResult(
+                gradleUpdateInfo = null,
+                updateInfos = emptyMap(),
+                ignoredUpdateInfos = emptyList(),
+                selfUpdateInfo = null,
+                versionCatalog = null,
+                versionCatalogInfo = null,
+            )
+            val configPath = "do-not-check-self-updates.toml".toPath()
+            fileSystem.write(configPath) {
+                writeUtf8(
+                    """
+                    versionCatalogPaths = ["${versionCatalogPath}"]
+                    doNotCheckSelfUpdates = true
+                    """.trimIndent()
+                )
+            }
+            val cli = CaupainCLI(
+                fileSystem = fileSystem,
+                defaultDispatcher = testDispatcher,
+                ioDispatcher = testDispatcher,
+                createUpdateChecker = { _, _, _, _, _, selfUpdateResolver ->
+                    assertEquals(null, selfUpdateResolver)
+                    checker
+                },
+                createVersionReplacer = { _, _, _ -> replacer }
+            )
+            val result = cli.test(
+                listOf(
+                    "-c",
+                    configPath.toString(),
+                    "--gradle-wrapper-properties",
+                    wrapperPropertiesPath.toString(),
+                )
+            )
+            assertEquals(0, result.statusCode)
+        }
+    }
+
+    @Test
     fun testListPolicies() {
         runTest(testDispatcher) {
             val policies = listOf<Policy>(

--- a/cli/src/commonTest/kotlin/com/deezer/caupain/cli/CaupainCLITest.kt
+++ b/cli/src/commonTest/kotlin/com/deezer/caupain/cli/CaupainCLITest.kt
@@ -216,6 +216,40 @@ class CaupainCLITest {
     }
 
     @Test
+    fun testDoNotCheckSelfUpdates() {
+        runTest(testDispatcher) {
+            everySuspend { checker.checkForUpdates() } returns DependenciesUpdateResult(
+                gradleUpdateInfo = null,
+                updateInfos = emptyMap(),
+                ignoredUpdateInfos = emptyList(),
+                selfUpdateInfo = null,
+                versionCatalog = null,
+                versionCatalogInfo = null,
+            )
+            val cli = CaupainCLI(
+                fileSystem = fileSystem,
+                defaultDispatcher = testDispatcher,
+                ioDispatcher = testDispatcher,
+                createUpdateChecker = { _, _, _, _, _, selfUpdateResolver ->
+                    assertEquals(null, selfUpdateResolver)
+                    checker
+                },
+                createVersionReplacer = { _, _, _ -> replacer }
+            )
+            val result = cli.test(
+                listOf(
+                    "-i",
+                    versionCatalogPath.toString(),
+                    "--do-not-check-self-updates",
+                    "--gradle-wrapper-properties",
+                    wrapperPropertiesPath.toString(),
+                )
+            )
+            assertEquals(0, result.statusCode)
+        }
+    }
+
+    @Test
     fun testListPolicies() {
         runTest(testDispatcher) {
             val policies = listOf<Policy>(

--- a/cli/src/commonTest/kotlin/com/deezer/caupain/cli/ConfigurationParsingTest.kt
+++ b/cli/src/commonTest/kotlin/com/deezer/caupain/cli/ConfigurationParsingTest.kt
@@ -133,6 +133,7 @@ class ConfigurationParsingTest {
             ),
             actual = result.filters,
         )
+        assertEquals(true, result.doNotCheckSelfUpdates)
     }
 }
 
@@ -164,6 +165,7 @@ includedLibraries = [
     { group = "com.example2.included.**" }
 ]
 includedPlugins = [ "com.included.first", "com.included.second" ]
+doNotCheckSelfUpdates = true
 [[ repositories ]]
 default = "mavenCentral"
 includes = [

--- a/cli/src/jvmTest/kotlin/com/deezer/caupain/cli/CaupainCLIConfigTest.kt
+++ b/cli/src/jvmTest/kotlin/com/deezer/caupain/cli/CaupainCLIConfigTest.kt
@@ -185,6 +185,7 @@ class CaupainCLIConfigTest {
                     searchReleaseNote = false,
                     githubToken = "githubTokenConf",
                     verifyExistence = true,
+                    doNotCheckSelfUpdates = true,
                 )
             }
             when {
@@ -443,7 +444,8 @@ private data class TestConfiguration(
     override val checkIgnored: Boolean?,
     override val searchReleaseNote: Boolean?,
     override val githubToken: String?,
-    override val verifyExistence: Boolean?
+    override val verifyExistence: Boolean?,
+    override val doNotCheckSelfUpdates: Boolean?,
 ) : ParsedConfiguration {
 
     var didValidate = false

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -318,6 +318,8 @@ searchReleaseNotes = true
 // Note: This may slow down the checking process as it adds extra network requests.
 // Default is false.
 verifyExistence = true
+// Whether to skip checking for updates to the Caupain Gradle plugin itself. Default is false.
+doNotCheckSelfUpdates = true
 ```
 
 ## In-place update

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -25,6 +25,7 @@ public abstract class com/deezer/caupain/plugin/DependenciesUpdateExtension {
 	public static synthetic fun excludeLibrary$default (Lcom/deezer/caupain/plugin/DependenciesUpdateExtension;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun excludePluginIds ([Ljava/lang/String;)V
 	public final fun getCheckIgnored ()Lorg/gradle/api/provider/Property;
+	public final fun getDoNotCheckSelfUpdates ()Lorg/gradle/api/provider/Property;
 	public final fun getExcludedKeys ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getExcludedLibraries ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludedPluginIds ()Lorg/gradle/api/provider/SetProperty;
@@ -58,6 +59,7 @@ public class com/deezer/caupain/plugin/DependenciesUpdateTask : org/gradle/api/D
 	public final fun customFormatter (Lcom/deezer/caupain/plugin/Formatter;)V
 	public final fun getCacheDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getCheckIgnored ()Lorg/gradle/api/provider/Property;
+	public final fun getDoNotCheckSelfUpdates ()Lorg/gradle/api/provider/Property;
 	public final fun getExcludedKeys ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getExcludedLibraries ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludedPluginIds ()Lorg/gradle/api/provider/SetProperty;

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -173,6 +173,29 @@ class CaupainPluginTest {
     }
 
     @Test
+    fun testDoNotCheckSelfUpdates(
+        @TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)
+    ) {
+        val project = createProject(
+            supplementaryCaupainConfiguration = "doNotCheckSelfUpdates.set(true)",
+        )
+        val result = build(
+            gradleVersion = gradleVersion,
+            projectDir = project.rootDir,
+            ":checkDependencyUpdates",
+            "--no-configuration-cache",
+            "--stacktrace",
+            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
+        )
+        assertEquals(TaskOutcome.SUCCESS, result.task(":checkDependencyUpdates")?.outcome)
+        assertEquals(
+            expected = expectedJsonResultWithoutSelfUpdate(gradleVersion.version),
+            actual = jsonOutputFile.readText().trim()
+        )
+        assertEquals(9, mockWebserverRule.server.requestCount)
+    }
+
+    @Test
     fun testReplace(@TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)) {
         val project = createProject()
         val result = build(
@@ -1217,6 +1240,82 @@ private fun expectedJsonResult(
             "plugins"
         ]
     }
+}    
+""".trimIndent().trim()
+
+@Language("JSON")
+private fun expectedJsonResultWithoutSelfUpdate(
+    gradleVersion: String,
+) = """
+{
+    "gradleUpdateInfo": {
+        "currentVersion": "$gradleVersion",
+        "updatedVersion": "99.0.0"
+    },
+    "updateInfos": {
+        "libraries": [
+            {
+                "dependency": "androidx-core-ktx",
+                "dependencyId": "androidx.core:core-ktx",
+                "name": "Core Kotlin Extensions",
+                "url": "https://developer.android.com/jetpack/androidx/releases/core#1.17.0",
+                "releaseNoteUrl": null,
+                "currentVersion": "1.16.0",
+                "updatedVersion": "1.17.0"
+            }
+        ],
+        "plugins": [
+            {
+                "dependency": "kotlin-android",
+                "dependencyId": "org.jetbrains.kotlin.android",
+                "name": "Kotlin Gradle Plugin",
+                "url": "https://kotlinlang.org/",
+                "releaseNoteUrl": null,
+                "currentVersion": "2.0.21",
+                "updatedVersion": "2.1.20"
+            }
+        ]
+    },
+    "ignoredUpdateInfos": [
+        {
+            "dependency": "ignored",
+            "dependencyId": "com.example:ignored",
+            "name": null,
+            "url": null,
+            "releaseNoteUrl": null,
+            "currentVersion": "1.0.0",
+            "updatedVersion": "1.1.0"
+        }
+    ],
+    "versionReferenceInfo": [
+        {
+            "id": "coreKtx",
+            "libraryKeys": [
+                "androidx-core-ktx"
+            ],
+            "updatedLibraries": {
+                "androidx-core-ktx": "1.17.0"
+            },
+            "pluginKeys": [],
+            "updatedPlugins": {},
+            "currentVersion": "1.16.0",
+            "updatedVersion": "1.17.0"
+        },
+        {
+            "id": "kotlin",
+            "libraryKeys": [],
+            "updatedLibraries": {},
+            "pluginKeys": [
+                "kotlin-android"
+            ],
+            "updatedPlugins": {
+                "kotlin-android": "2.1.20"
+            },
+            "currentVersion": "2.0.21",
+            "updatedVersion": "2.1.20"
+        }
+    ],
+    "selfUpdateInfo": null
 }    
 """.trimIndent().trim()
 

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependenciesUpdateExtension.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependenciesUpdateExtension.kt
@@ -155,6 +155,12 @@ abstract class DependenciesUpdateExtension @Inject internal constructor(objects:
     val verifyExistence: Property<Boolean> = objects.property<Boolean>().convention(false)
 
     /**
+     * Whether to skip checking for updates to the Caupain Gradle plugin itself.
+     * Default is false.
+     */
+    val doNotCheckSelfUpdates: Property<Boolean> = objects.property<Boolean>().convention(false)
+
+    /**
      * Configure repositories
      */
     fun repositories(action: Action<RepositoryHandler>) {

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependenciesUpdateTask.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependenciesUpdateTask.kt
@@ -170,6 +170,12 @@ open class DependenciesUpdateTask : DefaultTask() {
     val verifyExistence = project.objects.property<Boolean>()
 
     /**
+     * @see DependenciesUpdateExtension.doNotCheckSelfUpdates
+     */
+    @get:Internal
+    val doNotCheckSelfUpdates = project.objects.property<Boolean>()
+
+    /**
      * @see DependenciesUpdateExtension.gradleStabilityLevel
      */
     @get:Internal
@@ -242,7 +248,11 @@ open class DependenciesUpdateTask : DefaultTask() {
         val checker = DependencyUpdateChecker(
             configuration = configuration,
             logger = LoggerAdapter(logger),
-            selfUpdateResolver = PluginUpdateResolver,
+            selfUpdateResolver = if (doNotCheckSelfUpdates.get()) {
+                null
+            } else {
+                PluginUpdateResolver
+            },
             policies = policies,
             currentGradleVersion = GradleVersion.current().version,
             gradleVersionsUrl = gradleVersionsUrl,

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
@@ -78,6 +78,7 @@ open class DependencyUpdatePlugin : Plugin<Project> {
             searchReleaseNote.convention(ext.searchReleaseNote)
             githubToken.convention(ext.githubToken)
             verifyExistence.convention(ext.verifyExistence)
+            doNotCheckSelfUpdates.convention(ext.doNotCheckSelfUpdates)
         }
         target.tasks.register<DependenciesReplaceTask>("replaceOutdatedDependencies") {
             group = "verification"


### PR DESCRIPTION
## What does this PR do?
Adds a way to skip Caupain self-update checks in CLI and Gradle plugin:

CLI: new flag --do-not-check-self-updates
CLI config: new doNotCheckSelfUpdates = true in caupain.toml
Gradle plugin: new doNotCheckSelfUpdates option on the caupain extension
When enabled, Caupain no longer checks for updates to itself (GitHub Releases in CLI, plugin repositories in Gradle plugin). Default behavior is unchanged.

Also includes README updates, shell completions, tests, and CHANGELOG entries.

Feature requses issue number #89 

## Checklist
- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.