### PR TITLE
Disable configuration cache for dependencies tasks

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -48,6 +48,8 @@ import java.io.File
 import java.io.StringWriter
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.fail
 
 @RunWith(TestParameterInjector::class)
 class CaupainPluginTest {
@@ -174,17 +176,25 @@ class CaupainPluginTest {
         )
     ) {
         val project = createProject()
-        val output = build(
+        build(
             gradleVersion = gradleVersion,
             projectDir = project.rootDir,
             ":checkDependencyUpdates",
             "--configuration-cache",
             "--stacktrace",
             "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
-        ).output
-        assertContains(
-            output.toString(),
-            "Configuration cache entry discarded because incompatible task was found: 'task `:checkDependencyUpdates`"
+        )
+        val result = build(
+            gradleVersion = gradleVersion,
+            projectDir = project.rootDir,
+            ":checkDependencyUpdates",
+            "--configuration-cache",
+            "--stacktrace",
+            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
+        )
+        assertNotEquals(
+            illegal = TaskOutcome.FROM_CACHE,
+            actual = result.task(":checkDependencyUpdates")?.outcome
         )
     }
 

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -27,7 +27,6 @@ package com.deezer.caupain.plugin
 import com.autonomousapps.kit.AbstractGradleProject.Companion.PLUGIN_UNDER_TEST_VERSION
 import com.autonomousapps.kit.GradleBuilder.build
 import com.autonomousapps.kit.GradleBuilder.runner
-import com.autonomousapps.kit.GradleProject
 import com.google.testing.junit.testparameterinjector.KotlinTestParameters.testValuesIn
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -37,8 +36,6 @@ import mockwebserver3.MockResponse
 import mockwebserver3.RecordedRequest
 import mockwebserver3.junit4.MockWebServerRule
 import okhttp3.Headers
-import okio.buffer
-import okio.source
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import org.intellij.lang.annotations.Language
@@ -49,13 +46,8 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.StringWriter
-import kotlin.io.path.div
-import kotlin.io.path.isDirectory
-import kotlin.io.path.name
-import kotlin.io.path.walk
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 @RunWith(TestParameterInjector::class)
 class CaupainPluginTest {

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -174,14 +174,6 @@ class CaupainPluginTest {
         )
     ) {
         val project = createProject()
-        build(
-            gradleVersion = gradleVersion,
-            projectDir = project.rootDir,
-            ":checkDependencyUpdates",
-            "--configuration-cache",
-            "--stacktrace",
-            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
-        )
         val output = build(
             gradleVersion = gradleVersion,
             projectDir = project.rootDir,

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -168,6 +168,27 @@ class CaupainPluginTest {
     }
 
     @Test
+    fun testConfigurationCacheIncompatible(
+        @TestParameter gradleVersion: GradleVersion = testValuesIn(
+            GRADLE_TESTED_VERSIONS
+        )
+    ) {
+        val project = createProject()
+        val output = build(
+            gradleVersion = gradleVersion,
+            projectDir = project.rootDir,
+            ":checkDependencyUpdates",
+            "--configuration-cache",
+            "--stacktrace",
+            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
+        ).output
+        assertContains(
+            output.toString(),
+            "Configuration cache entry discarded because incompatible task was found: 'task `:checkDependencyUpdates`"
+        )
+    }
+
+    @Test
     fun testDoNotCheckSelfUpdates(
         @TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)
     ) {
@@ -190,7 +211,11 @@ class CaupainPluginTest {
     }
 
     @Test
-    fun testReplace(@TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)) {
+    fun testReplace(
+        @TestParameter gradleVersion: GradleVersion = testValuesIn(
+            GRADLE_TESTED_VERSIONS
+        )
+    ) {
         val project = createProject()
         val result = build(
             gradleVersion = gradleVersion,
@@ -208,7 +233,11 @@ class CaupainPluginTest {
     }
 
     @Test
-    fun testMultipleFiles(@TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)) {
+    fun testMultipleFiles(
+        @TestParameter gradleVersion: GradleVersion = testValuesIn(
+            GRADLE_TESTED_VERSIONS
+        )
+    ) {
         val project = createProject(
             supplementaryCaupainConfiguration = """
             versionCatalogFile.set(file("gradle/other.versions.toml"))

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -27,6 +27,7 @@ package com.deezer.caupain.plugin
 import com.autonomousapps.kit.AbstractGradleProject.Companion.PLUGIN_UNDER_TEST_VERSION
 import com.autonomousapps.kit.GradleBuilder.build
 import com.autonomousapps.kit.GradleBuilder.runner
+import com.autonomousapps.kit.GradleProject
 import com.google.testing.junit.testparameterinjector.KotlinTestParameters.testValuesIn
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -36,6 +37,8 @@ import mockwebserver3.MockResponse
 import mockwebserver3.RecordedRequest
 import mockwebserver3.junit4.MockWebServerRule
 import okhttp3.Headers
+import okio.buffer
+import okio.source
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import org.intellij.lang.annotations.Language
@@ -46,10 +49,13 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.StringWriter
+import kotlin.io.path.div
+import kotlin.io.path.isDirectory
+import kotlin.io.path.name
+import kotlin.io.path.walk
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.fail
 
 @RunWith(TestParameterInjector::class)
 class CaupainPluginTest {
@@ -184,18 +190,17 @@ class CaupainPluginTest {
             "--stacktrace",
             "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
         )
-        val result = build(
+        val output = build(
             gradleVersion = gradleVersion,
             projectDir = project.rootDir,
             ":checkDependencyUpdates",
             "--configuration-cache",
             "--stacktrace",
             "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
-        )
-        assertNotEquals(
-            illegal = TaskOutcome.FROM_CACHE,
-            actual = result.task(":checkDependencyUpdates")?.outcome
-        )
+        ).output
+        assertContains(output, "configuration cache", ignoreCase = true)
+        assertContains(output, "checkDependencyUpdates", ignoreCase = true)
+        assertContains(output, "incompatible", ignoreCase = true)
     }
 
     @Test

--- a/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/com/deezer/caupain/plugin/CaupainPluginTest.kt
@@ -168,29 +168,6 @@ class CaupainPluginTest {
     }
 
     @Test
-    fun testConfigurationCache(@TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)) {
-        val project = createProject()
-        build(
-            gradleVersion = gradleVersion,
-            projectDir = project.rootDir,
-            ":checkDependencyUpdates",
-            "--configuration-cache",
-            "--stacktrace",
-            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
-        )
-        val output = StringWriter()
-        runner(
-            gradleVersion = gradleVersion,
-            projectDir = project.rootDir,
-            ":checkDependencyUpdates",
-            "--configuration-cache",
-            "--stacktrace",
-            "-Pcaupain.gradleVersionsUrl=${mockWebserverRule.server.url("gradle")}"
-        ).forwardStdOutput(output).build()
-        assertContains(output.toString(), "Reusing configuration cache")
-    }
-
-    @Test
     fun testDoNotCheckSelfUpdates(
         @TestParameter gradleVersion: GradleVersion = testValuesIn(GRADLE_TESTED_VERSIONS)
     ) {

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
@@ -83,8 +83,7 @@ open class DependencyUpdatePlugin : Plugin<Project> {
         }
         target.tasks.register<DependenciesReplaceTask>("replaceOutdatedDependencies") {
             group = "verification"
-            description = "Check for dependency updates"
-            notCompatibleWithConfigurationCache("Uses Gradle internal API for repositories")
+            description = "Replace dependency updates in-line with their latest versions"
             versionCatalogFile.convention(
                 versionCatalogFilesProvider.map { files ->
                     files.firstNotNullOf { it as? RegularFile }

--- a/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
+++ b/gradle-plugin/src/main/java/com/deezer/caupain/plugin/DependencyUpdatePlugin.kt
@@ -59,6 +59,7 @@ open class DependencyUpdatePlugin : Plugin<Project> {
         val checkTaskProvider = target.tasks.register<DependenciesUpdateTask>("checkDependencyUpdates") {
             group = "verification"
             description = "Check for dependency updates"
+            notCompatibleWithConfigurationCache("Uses Gradle internal API for repositories")
             versionCatalogFiles.convention(versionCatalogFilesProvider)
             excludedKeys.convention(ext.excludedKeys)
             excludedLibraries.convention(ext.excludedLibraries)
@@ -83,6 +84,7 @@ open class DependencyUpdatePlugin : Plugin<Project> {
         target.tasks.register<DependenciesReplaceTask>("replaceOutdatedDependencies") {
             group = "verification"
             description = "Check for dependency updates"
+            notCompatibleWithConfigurationCache("Uses Gradle internal API for repositories")
             versionCatalogFile.convention(
                 versionCatalogFilesProvider.map { files ->
                     files.firstNotNullOf { it as? RegularFile }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ kotlin.native.ignoreDisabledTargets=true
 #Gradle
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 
 #Caching
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ kotlin.native.ignoreDisabledTargets=true
 #Gradle
 org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=1g"
 org.gradle.parallel=true
-org.gradle.tooling.parallel=true
 
 #Caching
 org.gradle.caching=true


### PR DESCRIPTION
## What does this PR do?

This marks the Gradle tasks as not compatible with configuration cache, as they cannot be easily made so because of the repositories. Besides, thes are not "common" tasks so this shouldn't be too much of an issue.

## Issue number, if applicable

Fixes #88 

## Checklist
- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.