### PR TITLE
Avoid name conflict when plugin and library have the same key

### DIFF
--- a/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
@@ -406,6 +406,7 @@ internal class DefaultDependencyUpdateChecker(
                                         logger.info("Found updated version ${updatedVersion.updatedVersion} for ${dep.moduleId}")
                                         updatedVersionsMutex.withLock {
                                             val result = DependencyUpdateResult(
+                                                type = dep.type,
                                                 dependencyKey = key,
                                                 dependency = dep,
                                                 repository = updatedVersion.repository,
@@ -496,11 +497,7 @@ internal class DefaultDependencyUpdateChecker(
         val updatesInfos = mutableMapOf<UpdateInfo.Type, MutableList<UpdateInfo>>()
         for (result in updatedVersions) {
             logger.info("Finding release note info for ${result.dependency.moduleId}")
-            val type = when (result.dependency) {
-                is Dependency.Library -> UpdateInfo.Type.LIBRARY
-                is Dependency.Plugin -> UpdateInfo.Type.PLUGIN
-            }
-            val mavenInfo = mavenInfos[result.dependencyKey]
+            val mavenInfo = mavenInfos[DependencyKey(result)]
             val releaseNoteUrl = if (configuration.searchReleaseNote) {
                 releaseNoteResolver.getReleaseNoteUrl(
                     mavenInfo = mavenInfo,
@@ -517,9 +514,9 @@ internal class DefaultDependencyUpdateChecker(
                 mavenInfo = mavenInfo,
                 releaseNoteUrl = releaseNoteUrl
             )
-            val infosForType = updatesInfos[type]
-                ?: mutableListOf<UpdateInfo>().also { updatesInfos[type] = it }
-            infosForType.add(updateInfo)
+            updatesInfos
+                .getOrPut(result.type) { mutableListOf() }
+                .add(updateInfo)
             val percentage = ++completed * 50 / nbSteps + 50
             progressFlow.value = DependencyUpdateChecker.Progress.Determinate(
                 taskName = GATHERING_INFO_TASK,
@@ -533,9 +530,9 @@ internal class DefaultDependencyUpdateChecker(
     private suspend inline fun getMavenInfos(
         updatedVersions: List<DependencyUpdateResult>,
         crossinline onStepFinished: () -> Unit,
-    ): Map<String, MavenInfo> {
+    ): Map<DependencyKey, MavenInfo> {
         val mavenInfoMutex = Mutex()
-        val mavenInfos = mutableMapOf<String, MavenInfo>()
+        val mavenInfos = mutableMapOf<DependencyKey, MavenInfo>()
         coroutineScope {
             updatedVersions
                 .map { result ->
@@ -548,7 +545,7 @@ internal class DefaultDependencyUpdateChecker(
                         )
                         if (mavenInfo != null) {
                             mavenInfoMutex.withLock {
-                                mavenInfos[result.dependencyKey] = mavenInfo
+                                mavenInfos[DependencyKey(result)] = mavenInfo
                             }
                         }
                         onStepFinished()
@@ -584,12 +581,25 @@ internal class DefaultDependencyUpdateChecker(
     )
 
     private data class DependencyUpdateResult(
+        val type: UpdateInfo.Type,
         val dependencyKey: String,
         val dependency: Dependency,
         val repository: Repository,
         val currentVersion: Version.Resolved,
         val updatedVersion: GradleDependencyVersion.Static,
     )
+
+    private data class DependencyKey(val type: UpdateInfo.Type, val key: String) {
+        constructor(result: DependencyUpdateResult) : this(result.type, result.dependencyKey)
+    }
+
+    companion object {
+        private val Dependency.type: UpdateInfo.Type
+            get() = when (this) {
+                is Dependency.Library -> UpdateInfo.Type.LIBRARY
+                is Dependency.Plugin -> UpdateInfo.Type.PLUGIN
+            }
+    }
 }
 
 /**
@@ -626,8 +636,9 @@ public class CorruptedCacheException(
 /**
  * Exception thrown when the cache directory is unavailable or cannot be created.
  */
-public class UnavailableCacheException(public val cacheDir: Path, cause: Throwable) : CaupainException(
-    message = "Cache directory $cacheDir is unavailable. Please check your file system " +
-            "permissions and try again, or disable the cache.",
-    cause = cause,
-)
+public class UnavailableCacheException(public val cacheDir: Path, cause: Throwable) :
+    CaupainException(
+        message = "Cache directory $cacheDir is unavailable. Please check your file system " +
+                "permissions and try again, or disable the cache.",
+        cause = cause,
+    )

--- a/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/DependencyUpdateChecker.kt
@@ -384,7 +384,7 @@ internal class DefaultDependencyUpdateChecker(
         var selfUpdateInfo: SelfUpdateInfo? = null
         val updatedVersions = mutableListOf<DependencyUpdateResult>()
         val ignoredVersions = mutableListOf<UpdateInfo>()
-        var nbDependencies = parseResults.sumOf { it.versionCatalog.dependencies.size }
+        var nbDependencies = parseResults.sumOf { it.versionCatalog.nbDependencies }
         if (checkGradleUpdate) nbDependencies++
         if (checkSelfUpdate) nbDependencies++
         coroutineScope {
@@ -393,7 +393,6 @@ internal class DefaultDependencyUpdateChecker(
                 .flatMap { (versionCatalog, info) ->
                     versionCatalog
                         .dependencies
-                        .asSequence()
                         .map { (key, dep) ->
                             async {
                                 val isExcluded = !configuration.isIncluded(key, dep)

--- a/core/src/commonMain/kotlin/com/deezer/caupain/model/Dependency.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/model/Dependency.kt
@@ -123,6 +123,16 @@ public sealed interface Dependency {
     }
 }
 
+internal data class KeyedDependency(
+    val key: String,
+    val dependency: Dependency,
+) {
+    constructor(entry: Map.Entry<String, Dependency>) : this(
+        key = entry.key,
+        dependency = entry.value,
+    )
+}
+
 internal val Dependency.group: String?
     get() = when (this) {
         is Library -> group

--- a/core/src/commonMain/kotlin/com/deezer/caupain/model/versionCatalog/VersionCatalog.kt
+++ b/core/src/commonMain/kotlin/com/deezer/caupain/model/versionCatalog/VersionCatalog.kt
@@ -25,6 +25,7 @@
 package com.deezer.caupain.model.versionCatalog
 
 import com.deezer.caupain.model.Dependency
+import com.deezer.caupain.model.KeyedDependency
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.Serializable
 
@@ -38,6 +39,10 @@ public class VersionCatalog(
     public val libraries: Map<String, Dependency.Library> = emptyMap(),
     public val plugins: Map<String, Dependency.Plugin> = emptyMap()
 ) {
-    internal val dependencies: Map<String, Dependency>
-        get() = libraries + plugins
+    internal val nbDependencies: Int
+        get() = libraries.size + plugins.size
+
+    internal val dependencies: Sequence<KeyedDependency>
+        get() = libraries.asSequence().map(::KeyedDependency) +
+                plugins.asSequence().map(::KeyedDependency)
 }

--- a/core/src/commonTest/kotlin/com/deezer/caupain/DependencyUpdateCheckerTest.kt
+++ b/core/src/commonTest/kotlin/com/deezer/caupain/DependencyUpdateCheckerTest.kt
@@ -132,7 +132,7 @@ class DependencyUpdateCheckerTest {
                 }
             },
             ioDispatcher = testDispatcher,
-            versionCatalogParser = FixedVersionCatalogParser,
+            versionCatalogParser = FixedVersionCatalogParser(),
             logger = Logger.EMPTY,
             policies = DEFAULT_POLICIES,
             currentGradleVersion = "8.11",
@@ -273,7 +273,7 @@ class DependencyUpdateCheckerTest {
                 }
             },
             ioDispatcher = testDispatcher,
-            versionCatalogParser = FixedVersionCatalogParser,
+            versionCatalogParser = FixedVersionCatalogParser(),
             logger = Logger.EMPTY,
             policies = DEFAULT_POLICIES,
             currentGradleVersion = "8.11",
@@ -303,6 +303,54 @@ class DependencyUpdateCheckerTest {
         )
     }
 
+    @Test
+    fun testShadowConflict() = runTest(testDispatcher) {
+        val catalogPath = "libs.versions.toml".toPath()
+        fileSystem.write(catalogPath) {}
+        val configuration = Configuration(
+            repositories = listOf(SIGNED_REPOSITORY, BASE_REPOSITORY),
+            pluginRepositories = listOf(BASE_REPOSITORY, SIGNED_REPOSITORY),
+            versionCatalogPaths = listOf(catalogPath),
+            checkIgnored = true,
+            policies = listOf(AlwaysAcceptPolicy.name)
+        )
+        checker = DefaultDependencyUpdateChecker(
+            configuration = configuration,
+            fileSystem = fileSystem,
+            httpClient = HttpClient(engine) {
+                install(ContentNegotiation) {
+                    json(DefaultJson)
+                    serialization(ContentType.Any, DefaultXml)
+                }
+            },
+            ioDispatcher = testDispatcher,
+            versionCatalogParser = FixedVersionCatalogParser(
+                catalog = VERSION_CATALOG_SHADOW,
+                info = VersionCatalogInfo()
+            ),
+            logger = Logger.EMPTY,
+            policies = DEFAULT_POLICIES,
+            currentGradleVersion = "8.11",
+            selfUpdateResolver = FixedSelfUpdateResolver
+        )
+        assertEquals(
+            expected = mapOf(
+                UpdateInfo.Type.LIBRARY to listOf(
+                    UpdateInfo(
+                        dependency = "testName",
+                        dependencyId = "org.codehaus.groovy:groovy",
+                        name = "Groovy core",
+                        url = "https://groovy-lang.org/",
+                        currentVersion = "3.0.5-alpha-1".toSimpleVersion(),
+                        updatedVersion = "3.0.6".toStaticVersion()
+                    ),
+                ),
+                UpdateInfo.Type.PLUGIN to emptyList(),
+            ),
+            actual = checker.checkForUpdates().updateInfos
+        )
+    }
+
     companion object {
         private inline fun <reified T> MockRequestHandleScope.respondElement(element: T): HttpResponseData {
             return respond(
@@ -328,13 +376,16 @@ class DependencyUpdateCheckerTest {
             password = PASSWORD
         )
 
-        private object FixedVersionCatalogParser : VersionCatalogParser {
+        private class FixedVersionCatalogParser(
+            private val catalog: VersionCatalog? = null,
+            private val info: VersionCatalogInfo = VersionCatalogInfo(
+                ignores = VersionCatalogInfo.Ignores(libraryKeys = setOf("groovy-other"))
+            )
+        ) : VersionCatalogParser {
             override suspend fun parseDependencyInfo(versionCatalogPath: Path): VersionCatalogParseResult =
                 VersionCatalogParseResult(
-                    versionCatalog = VERSION_CATALOGS[versionCatalogPath]!!,
-                    info = VersionCatalogInfo(
-                        ignores = VersionCatalogInfo.Ignores(libraryKeys = setOf("groovy-other"))
-                    ),
+                    versionCatalog = catalog ?: VERSION_CATALOGS[versionCatalogPath]!!,
+                    info = info,
                 )
         }
 
@@ -512,6 +563,21 @@ class DependencyUpdateCheckerTest {
                 "versions" to Dependency.Plugin(
                     id = "com.github.ben-manes.versions",
                     version = Version.Simple(GradleDependencyVersion.Snapshot("0.45.0-SNAPSHOT"))
+                )
+            )
+        )
+
+        private val VERSION_CATALOG_SHADOW = VersionCatalog(
+            libraries = mapOf(
+                "testName" to Dependency.Library(
+                    module = "org.codehaus.groovy:groovy",
+                    version = Version.Simple(GradleDependencyVersion.Exact("3.0.5-alpha-1"))
+                ),
+            ),
+            plugins = mapOf(
+                "testName" to Dependency.Plugin(
+                    id = "com.github.ben-manes.versions",
+                    version = Version.Simple(GradleDependencyVersion.Exact("1.0.0"))
                 )
             )
         )


### PR DESCRIPTION
## What does this PR do?

If a plugin and a library had the same key in the version catalog, they were conflated during version resolution and only the plugin was checked. This solves this issue by not using a `Map` to return all dependencies.

## Issue number, if applicable

Fixes #95

## Checklist
- [x] I have read the [contributing guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have documented my code if it is included in the public API.
- [x] I have added tests for my code and ran them via `./gradlew check`.